### PR TITLE
temporary hyperlink for `contact us`

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
           api.data.gov API requests. Exceeding these limits will lead to your
           API key being temporarily blocked from making further requests. The
           block will automatically be lifted by waiting an hour. If you need
-          higher rate limits, contact us.</p>
+          higher rate limits, <a href="https://github.com/nasa/api-docs/issues">contact us</a>.</p>
 
         <h2 id="demo_key-rate-limits">DEMO_KEY Rate Limits</h2>
 


### PR DESCRIPTION
I'm sure you'll want to change in the long run but this is at least a good placeholder.  Suggest picking another or merging this in the meantime.   
