### PR TITLE
Fix API_Template link and add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+api-docs
+========
+
+This repository contains the front-end for http://nasa.github.io/api-docs/. This site will be CNAME mapped to api.nasa.gov
+
+This project contains API developer pages for available NASA public APIs and houses web components to allow NASA branded API pages to be integrated with the GSA api.data.gov system.
+
+This site is built using [Jekyll](http://jekyllrb.com/).
+
+### Points of Contact:
+- Jason Duley jason.duley@nasa.gov 
+- Dan Hammer daniel.s.hammer@nasa.gov

--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@
 			
 			<!-- Contributing -->
 			<h1 id="contributing">Contributing</h1>
-        	<p>Next, why not contribute to api.nasa.gov if you already have excellent data or a Web Service that can benefit the NASA community. Once you have a running service and a robust API in place, submit an <a href="https://github.com/nasa/blob/staging/API_template/your_api.html">API template</a> describing your API and submit to us by either <a href="mailto:jason.duley@nasa.gov">email</a> or GitHub a pull request.</p>
+        	<p>Next, why not contribute to api.nasa.gov if you already have excellent data or a Web Service that can benefit the NASA community. Once you have a running service and a robust API in place, submit an <a href="/API_template/your_api.html">API template</a> describing your API and submit to us by either <a href="mailto:jason.duley@nasa.gov">email</a> or GitHub a pull request.</p>
 			<div style=" text-align: center; width: 100%"><img src="images/getting_started_contribute" style="margin: auto; margin-top: 25px;"/></div>
 
 			<!-- About -->


### PR DESCRIPTION
- Replaced `<a href="https://github.com/nasa/blob/staging/API_template/your_api.html">` with `<a href="/API_template/your_api.html">`.
- Added a README
