### PR TITLE
Fix header title on mobile when there is a warning banner

### DIFF
--- a/assets/css/indexFormat.css
+++ b/assets/css/indexFormat.css
@@ -116,8 +116,10 @@ abbr{
   line-height: 6rem;
 }
 .usa-logo-text{
+  position: relative;
   font-size: 2.3rem;
   padding-left: 2rem;
+  white-space: nowrap;
 }
 .usa-menu-btn{
   height: 6rem;
@@ -160,7 +162,6 @@ a:focus {
     line-height: 7.8rem;
   }
   .usa-logo-text{
-    white-space:nowrap;
     font-size: 3rem !important;
     margin-bottom: 30px;
   }


### PR DESCRIPTION
**Before:**

![nasa-broken](https://user-images.githubusercontent.com/930064/205925905-24992001-eb6f-4933-a790-3d0ffe312f8f.png)

Notice how the `{ APIs }` text is in the middle of the orange banner.

**After:**

![nasa-fixed](https://user-images.githubusercontent.com/930064/205925909-cfc17ff4-477c-40b0-ab0e-7025c5d54c38.png)
