### PR TITLE
Removed Government Shutdown Warning from Banner point#3

### DIFF
--- a/assets/html/header.html
+++ b/assets/html/header.html
@@ -36,7 +36,6 @@
   </section>
   <section class="alert">
       <span class="closebtn" onclick="this.parentElement.style.display='none';">&times;</span>
-      <p><strong>Due to the lapse in federal government funding, NASA is not updating this website. We sincerely regret this inconvenience.</strong></p>
       <p><strong>⚠ Please Note:</strong> The Earth API has been archived and replaced with <a href="https://api.nasa.gov/#gibs">Earthdata GIBS API</a>. The <a href="https://github.com/corincerami/mars-photo-api">Mars Rover API</a> has also been archived. Please update your bookmarks or projects as needed.</p>
     </section>
   <header style = "box-shadow: 0px 4px 8px darkgrey !important;" class="usa-header usa-header-basic" role="banner" id = "myHeader">


### PR DESCRIPTION
Removed the line saying "Due to the lapse in federal government funding, NASA is not updating this website. We sincerely regret this inconvenience." from the warning banner on api.nasa.gov.